### PR TITLE
Simplify Tich and Laberit job date ranges to years only.

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -84,7 +84,7 @@ export const en: Dictionary = {
     jobs: [
       {
         title: 'Tich Consulting (ASISA Group), Database Consultant / Parameterization',
-        period: 'Jan 2024 – Present · 2 years 7 months',
+        period: '2024 – Present',
         place: 'Alicante, Spain',
         bullets: [
           'Parameterization and optimization of SQL Server databases for more than 200 ASISA healthcare centers and international clinics.',
@@ -96,7 +96,7 @@ export const en: Dictionary = {
       },
       {
         title: 'Laberit, Implanter',
-        period: 'Jan 2019 – Jan 2024 · 5 years 1 month',
+        period: '2019 – 2024',
         place: 'Valencia, Spain',
         bullets: [
           'Technical coordination of the SINA program at IVO and HCB Benidorm.',

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -113,7 +113,7 @@ export const es: Dictionary = {
     jobs: [
       {
         title: 'Tich Consulting (Grupo ASISA), Consultor BBDD / Parametrización',
-        period: 'Ene 2024 – presente · 2 años 7 meses',
+        period: '2024 – presente',
         place: 'Alicante, España',
         bullets: [
           'Parametrización y optimización de bases de datos SQL Server para más de 200 centros sanitarios de ASISA y clínicas internacionales.',
@@ -125,7 +125,7 @@ export const es: Dictionary = {
       },
       {
         title: 'Laberit, Implantador',
-        period: 'Ene 2019 – Ene 2024 · 5 años 1 mes',
+        period: '2019 – 2024',
         place: 'Valencia, España',
         bullets: [
           'Coordinación técnica del programa SINA en IVO y HCB Benidorm.',


### PR DESCRIPTION
Drop month labels and tenure durations from the public experience entries.