### PR TITLE
Fix skills grid and aptitude tag spacing after Astro migration.

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -589,6 +589,25 @@ section {
   margin-bottom: 10px;
 }
 
+.resume .resume-item .aptitudes-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+  padding-bottom: 4px;
+}
+
+.resume .resume-item .aptitudes-list .aptitudes {
+  font-size: 12px;
+  background: #e4edf9;
+  padding: 5px 15px;
+  display: inline-block;
+  font-weight: 600;
+  margin: 0;
+  line-height: 1.4;
+  border-radius: 2px;
+}
+
 /*-----------Pills-------------------*/
 .resume .nav-pills {
   border-bottom: 1px solid rgba(72, 86, 100), 0.2);
@@ -974,6 +993,35 @@ body.portfolio-modal-open {
     -moz-box-shadow: 0 0 5px rgba(0,0,0,0.06);
     -ms-box-shadow: 0 0 5px rgba(0,0,0,0.06);
     box-shadow: 0 0 5px rgba(0,0,0,0.06);
+}
+
+.skills-tab-content {
+  margin-top: 1rem;
+}
+
+.skills-icons-row {
+  margin-left: 0;
+  margin-right: 0;
+  margin-bottom: 1rem;
+}
+
+.skills-icons-row:last-child {
+  margin-bottom: 0;
+}
+
+.skills-icons-row > [class*="col-"] {
+  padding-left: 8px;
+  padding-right: 8px;
+  margin-bottom: 0.75rem;
+}
+
+.skills .skill-icon {
+  font-size: 3rem;
+  border-radius: 3px;
+  box-shadow: 2px 2px 0 2px #ccc;
+  display: inline-block;
+  line-height: 1;
+  vertical-align: middle;
 }
 
 

--- a/src/components/JobsList.astro
+++ b/src/components/JobsList.astro
@@ -22,10 +22,14 @@ const jobs = t.resume.jobs;
         {job.bullets.map((b) => (
           <li>{b}</li>
         ))}
-        {job.skills.map((s) => (
-          <li class="aptitudes">{s}</li>
-        ))}
       </ul>
+      {job.skills.length > 0 && (
+        <div class="aptitudes-list">
+          {job.skills.map((skill) => (
+            <span class="aptitudes">{skill}</span>
+          ))}
+        </div>
+      )}
     </div>
   ))
 }

--- a/src/components/Skills.astro
+++ b/src/components/Skills.astro
@@ -1,5 +1,5 @@
 ---
-import type { Dictionary } from '../i18n';
+import type { Dictionary, SkillIcon } from '../i18n';
 
 interface Props {
   t: Dictionary;
@@ -7,7 +7,14 @@ interface Props {
 
 const { t } = Astro.props;
 const s = t.skills;
-const iconStyle = 'Font-size:3rem; border-radius: 3px;box-shadow: 2px 2px 0px 2px #ccc;';
+
+function chunkIcons(icons: SkillIcon[], size = 3): SkillIcon[][] {
+  const rows: SkillIcon[][] = [];
+  for (let i = 0; i < icons.length; i += size) {
+    rows.push(icons.slice(i, i + size));
+  }
+  return rows;
+}
 ---
 
 <section id="skills" class="skills section-bg">
@@ -40,8 +47,7 @@ const iconStyle = 'Font-size:3rem; border-radius: 3px;box-shadow: 2px 2px 0px 2p
               }
             </ul>
           </div>
-          <br />
-          <div class="tab-content" id="myTabContent">
+          <div class="tab-content skills-tab-content" id="myTabContent">
             {
               s.tabs.map((tab, i) => (
                 <div
@@ -50,21 +56,21 @@ const iconStyle = 'Font-size:3rem; border-radius: 3px;box-shadow: 2px 2px 0px 2p
                   role="tabpanel"
                   aria-labelledby={`${tab.id}-tab`}
                 >
-                  <div class="container">
-                    <div class="row">
-                      {(s.groups[tab.id] ?? []).map((icon) => (
-                        <div class="col">
+                  {chunkIcons(s.groups[tab.id] ?? []).map((row) => (
+                    <div class="row skills-icons-row">
+                      {row.map((icon) => (
+                        <div class="col-4 text-center">
                           {icon.href ? (
-                            <a href={icon.href}>
-                              <i class={icon.iconClass} style={iconStyle}></i>
+                            <a href={icon.href} aria-label={icon.iconClass}>
+                              <i class={`skill-icon ${icon.iconClass}`}></i>
                             </a>
                           ) : (
-                            <i class={icon.iconClass} style={iconStyle}></i>
+                            <i class={`skill-icon ${icon.iconClass}`}></i>
                           )}
                         </div>
                       ))}
                     </div>
-                  </div>
+                  ))}
                 </div>
               ))
             }


### PR DESCRIPTION
Restore 3-column icon rows and move job skills into a flex wrap list so tags no longer show uneven gaps.