### PR TITLE
Fix mobile layout for skills icons and aptitude tags.

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -589,23 +589,25 @@ section {
   margin-bottom: 10px;
 }
 
-.resume .resume-item .aptitudes-list {
+.resume .resume-item ul.aptitudes-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 8px 0 0;
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin-top: 4px;
-  padding-bottom: 4px;
+  width: 100%;
+  box-sizing: border-box;
 }
 
-.resume .resume-item .aptitudes-list .aptitudes {
-  font-size: 12px;
-  background: #e4edf9;
-  padding: 5px 15px;
-  display: inline-block;
-  font-weight: 600;
-  margin: 0;
+.resume .resume-item ul.aptitudes-list > li,
+.resume .resume-item ul.aptitudes-list > li.aptitudes {
+  padding-bottom: 5px;
+  margin-bottom: 0;
+  margin-right: 0;
   line-height: 1.4;
   border-radius: 2px;
+  white-space: nowrap;
 }
 
 /*-----------Pills-------------------*/
@@ -977,7 +979,10 @@ body.portfolio-modal-open {
 --------------------------------------------------------------*/
 .panel-box {
     width: 100%;
-    float: left;
+    max-width: 100%;
+    float: none;
+    display: block;
+    box-sizing: border-box;
     height: auto;
     padding: 20px 20px 25px;
     background: #fff;
@@ -997,31 +1002,54 @@ body.portfolio-modal-open {
 
 .skills-tab-content {
   margin-top: 1rem;
+  width: 100%;
 }
 
-.skills-icons-row {
-  margin-left: 0;
-  margin-right: 0;
-  margin-bottom: 1rem;
+.skills .nav-tabs {
+  border-bottom: 1px solid #dee2e6;
 }
 
-.skills-icons-row:last-child {
-  margin-bottom: 0;
+.skills .nav-tabs .nav-link {
+  font-size: 0.9rem;
+  padding: 0.5rem 0.75rem;
 }
 
-.skills-icons-row > [class*="col-"] {
-  padding-left: 8px;
-  padding-right: 8px;
-  margin-bottom: 0.75rem;
+.skills-icons-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem 0.75rem;
+  width: 100%;
+  justify-items: center;
+  align-items: center;
+  box-sizing: border-box;
+}
+
+.skills-icon-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  text-decoration: none;
 }
 
 .skills .skill-icon {
-  font-size: 3rem;
+  font-size: clamp(2rem, 8vw, 3rem);
   border-radius: 3px;
   box-shadow: 2px 2px 0 2px #ccc;
   display: inline-block;
   line-height: 1;
   vertical-align: middle;
+}
+
+@media (max-width: 575.98px) {
+  .skills .nav-tabs .nav-link {
+    font-size: 0.8rem;
+    padding: 0.4rem 0.55rem;
+  }
+
+  .skills-icons-grid {
+    gap: 1.1rem 0.5rem;
+  }
 }
 
 

--- a/src/components/JobsList.astro
+++ b/src/components/JobsList.astro
@@ -24,11 +24,11 @@ const jobs = t.resume.jobs;
         ))}
       </ul>
       {job.skills.length > 0 && (
-        <div class="aptitudes-list">
+        <ul class="aptitudes-list">
           {job.skills.map((skill) => (
-            <span class="aptitudes">{skill}</span>
+            <li class="aptitudes">{skill}</li>
           ))}
-        </div>
+        </ul>
       )}
     </div>
   ))

--- a/src/components/Skills.astro
+++ b/src/components/Skills.astro
@@ -1,5 +1,5 @@
 ---
-import type { Dictionary, SkillIcon } from '../i18n';
+import type { Dictionary } from '../i18n';
 
 interface Props {
   t: Dictionary;
@@ -7,14 +7,6 @@ interface Props {
 
 const { t } = Astro.props;
 const s = t.skills;
-
-function chunkIcons(icons: SkillIcon[], size = 3): SkillIcon[][] {
-  const rows: SkillIcon[][] = [];
-  for (let i = 0; i < icons.length; i += size) {
-    rows.push(icons.slice(i, i + size));
-  }
-  return rows;
-}
 ---
 
 <section id="skills" class="skills section-bg">
@@ -23,10 +15,10 @@ function chunkIcons(icons: SkillIcon[], size = 3): SkillIcon[][] {
       <h2>{s.title}</h2>
     </div>
     <div class="row skills-content">
-      <div class="col-lg-6" data-aos="fade-up">
+      <div class="col-12 col-lg-6" data-aos="fade-up">
         <div class="panel-box">
           <div class="tab-menu">
-            <ul class="nav nav-tabs" id="mytab" role="tablist">
+            <ul class="nav nav-tabs flex-wrap" id="mytab" role="tablist">
               {
                 s.tabs.map((tab, i) => (
                   <li class="nav-item" role="presentation">
@@ -56,21 +48,19 @@ function chunkIcons(icons: SkillIcon[], size = 3): SkillIcon[][] {
                   role="tabpanel"
                   aria-labelledby={`${tab.id}-tab`}
                 >
-                  {chunkIcons(s.groups[tab.id] ?? []).map((row) => (
-                    <div class="row skills-icons-row">
-                      {row.map((icon) => (
-                        <div class="col-4 text-center">
-                          {icon.href ? (
-                            <a href={icon.href} aria-label={icon.iconClass}>
-                              <i class={`skill-icon ${icon.iconClass}`}></i>
-                            </a>
-                          ) : (
-                            <i class={`skill-icon ${icon.iconClass}`}></i>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  ))}
+                  <div class="skills-icons-grid">
+                    {(s.groups[tab.id] ?? []).map((icon) =>
+                      icon.href ? (
+                        <a href={icon.href} class="skills-icon-link" aria-label={icon.iconClass}>
+                          <i class={`skill-icon ${icon.iconClass}`}></i>
+                        </a>
+                      ) : (
+                        <span class="skills-icon-link">
+                          <i class={`skill-icon ${icon.iconClass}`}></i>
+                        </span>
+                      )
+                    )}
+                  </div>
                 </div>
               ))
             }
@@ -78,7 +68,7 @@ function chunkIcons(icons: SkillIcon[], size = 3): SkillIcon[][] {
         </div>
       </div>
 
-      <div class="col-lg-6" data-aos="fade-up" data-aos-delay="100">
+      <div class="col-12 col-lg-6" data-aos="fade-up" data-aos-delay="100">
         <div class="panel-box">
           <h3>{s.languagesTitle}</h3>
           {s.languages.map((lang) => <p>{lang}</p>)}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -57,7 +57,7 @@ const enUrl = `${site}${base}en/`;
     <link href={withBase('assets/vendor/boxicons/css/boxicons.min.css')} rel="stylesheet" />
     <link href={withBase('assets/vendor/glightbox/css/glightbox.min.css')} rel="stylesheet" />
     <link href={withBase('assets/vendor/swiper/swiper-bundle.min.css')} rel="stylesheet" />
-    <link href={withBase('assets/css/style.css')} rel="stylesheet" />
+    <link href={`${withBase('assets/css/style.css')}?v=5.0.1`} rel="stylesheet" />
     <link
       href="https://cdnjs.cloudflare.com/ajax/libs/limonte-sweetalert2/4.0.6/sweetalert2.min.css"
       rel="stylesheet"


### PR DESCRIPTION
Use a full-width CSS grid, drop panel float, restore list-based skill chips, and bust CSS cache for mobile.