### PR TITLE
Point Pills gallery to pills-config after duplicate removal.

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -166,7 +166,7 @@ export const en: Dictionary = {
           'assets/img/pills/pills-evolucion.png',
           'assets/img/pills/pills-preguntas.png',
           'assets/img/pills/pills-perfil.png',
-          'assets/img/pills/pills-equipo-config.png',
+          'assets/img/pills/pills-config.png',
         ],
       },
       {

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -195,7 +195,7 @@ export const es: Dictionary = {
           'assets/img/pills/pills-evolucion.png',
           'assets/img/pills/pills-preguntas.png',
           'assets/img/pills/pills-perfil.png',
-          'assets/img/pills/pills-equipo-config.png',
+          'assets/img/pills/pills-config.png',
         ],
       },
       {


### PR DESCRIPTION
Avoid a broken reference to the deleted pills-equipo-config screenshot.